### PR TITLE
Removed github menu link and updated docs link to new website

### DIFF
--- a/roles/openshift_istio/files/elasticsearch_configmap.yml
+++ b/roles/openshift_istio/files/elasticsearch_configmap.yml
@@ -45,12 +45,8 @@ data:
           "label": "About Jaeger",
           "items": [
             {
-              "label": "GitHub",
-              "url": "https://github.com/jaegertracing/jaeger"
-            },
-            {
               "label": "Docs",
-              "url": "http://jaeger.readthedocs.io/en/latest/"
+              "url": "https://www.jaegertracing.io/docs/"
             }
           ]
         }


### PR DESCRIPTION
Not sure what links we should include in this menu, so just simplified it for now to refer to the community docs.
