### PR TITLE
Deploy one Elasticsearch node, remove ES probes

### DIFF
--- a/roles/openshift_istio/files/elasticsearch.yml
+++ b/roles/openshift_istio/files/elasticsearch.yml
@@ -16,7 +16,7 @@ metadata:
     app: elasticsearch
 spec:
   podManagementPolicy: OrderedReady
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: elasticsearch
@@ -35,14 +35,6 @@ spec:
           value: info
         image: ' '
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 9200
-          initialDelaySeconds: 30
-        readinessProbe:
-          tcpSocket:
-            port: 9300
         ports:
         - containerPort: 9200
           name: api


### PR DESCRIPTION
* deploy one ES node to avoid brain split. Alternative would be to deploy 3 nodes for HA. ECL by default deploys one node.
* remove probes see https://github.com/RHsyseng/docker-rhel-elasticsearch/issues/8 with linked references.

@knrc hi, could you please review?  cc @objectiser

Signed-off-by: Pavol Loffay <ploffay@redhat.com>